### PR TITLE
Remove add button from ModelAdmin

### DIFF
--- a/code/controllers/DataChangeAdmin.php
+++ b/code/controllers/DataChangeAdmin.php
@@ -4,12 +4,22 @@
  * @author marcus@symbiote.com.au
  * @license BSD License http://silverstripe.org/bsd-license/
  */
-class DataChangeAdmin extends ModelAdmin {
-	public static $managed_models = array(
-		'DataChangeRecord',
-	);
+class DataChangeAdmin extends ModelAdmin
+{
+    public static $managed_models = array(
+        'DataChangeRecord',
+    );
 
-	public static $url_segment = 'datachanges';
-	public static $menu_title = 'Data Changes';
+    public static $url_segment = 'datachanges';
+    public static $menu_title = 'Data Changes';
 
+    public function getEditForm($id = null, $fields = null)
+    {
+        $form = parent::getEditForm($id);
+        $gridField = $form->Fields()->fieldByName($this->modelClass);
+        $gridFieldConfig = $gridField->getConfig();
+        $gridFieldConfig->removeComponentsByType('GridFieldAddNewButton');
+
+        return $form;
+    }
 }


### PR DESCRIPTION
Remove DataChangeRecord GridFieldAddNewButton from DataChangeAdmin.

On the DataChangeAdmin screen the DataChangeRecord GridField displays the GridFieldAddNewButton to add new DataChangeRecords. There is no need to manually add records. This change removes the add button.