### PR TITLE
fix(PruneChangesBeforeJob): Remove unused / old code that retrieved a flat list of IDs as this can cause the job to not work if there are a lot of DataChangeRecord items.

### DIFF
--- a/code/jobs/PruneChangesBeforeJob.php
+++ b/code/jobs/PruneChangesBeforeJob.php
@@ -11,15 +11,23 @@ class PruneChangesBeforeJob extends AbstractQueuedJob
     
     public function __construct($priorTo = null)
     {
+        $ts = 0;
         if ($priorTo) {
             $ts = strtotime($priorTo);
-            if ($ts <= 0) {
-                $ts = time() - 90*86400;
-            }
-            $this->priorTo = $priorTo;
-            $this->pruneBefore = date('Y-m-d 00:00:00', $ts);
-            $this->totalSteps = DataChangeRecord::get()->filter('Created:LessThan', $this->pruneBefore)->count();
         }
+        if ($ts <= 0) {
+            $ts = time() - 90*86400;
+        }
+        $this->priorTo = $priorTo;
+        $this->pruneBefore = date('Y-m-d 00:00:00', $ts);
+        // NOTE(Jake): 2018-05-08
+        //
+        // Change steps to 1 as it's technically doing 
+        // this in 1 step now, this is to avoid an issue where 
+        // totalSteps=0 can occur and the job won't requeue itself.
+        // (When using ->count() off the DataList)
+        //
+        $this->totalSteps = 1;
     }
     
     public function getSignature()
@@ -32,24 +40,20 @@ class PruneChangesBeforeJob extends AbstractQueuedJob
         return "Prune data change track entries before " . $this->pruneBefore;
     }
     
-    public function setup()
-    {
-        $this->pruneIds = DataChangeRecord::get()->filter('Created:LessThan', $this->pruneBefore)->column();
-        $this->totalSteps = count($this->pruneIds);
-    }
-    
     public function process() {
-        $items = DataChangeRecord::get()->filter('Created:LessThan', $this->pruneBefore);
-		$max = $items->max('ID');
-        
-        $query = new SQLDelete('DataChangeRecord', '"ID" < \'' . $max . '\'');
-        $query->execute();
+        if ($this->totalSteps <= 0) {
+            $items = DataChangeRecord::get()->filter('Created:LessThan', $this->pruneBefore);
+            $max = $items->max('ID');
+            
+            $query = new SQLDelete('DataChangeRecord', '"ID" < \'' . $max . '\'');
+            $query->execute();
+        }
         
         $job = new PruneChangesBeforeJob($this->priorTo);
-        
+
         $next = date('Y-m-d 03:00:00', strtotime('tomorrow'));
         
-        $this->currentStep = $this->totalSteps;
+        $this->currentStep = 1;
         $this->isComplete = true;
         
         singleton('QueuedJobService')->queueJob($job, $next);


### PR DESCRIPTION
fix(PruneChangesBeforeJob): Remove unused / old code that retrieved a flat list of IDs as this can cause the job to not work if there are a lot of DataChangeRecord items.